### PR TITLE
Add io_uring-backed POSIX AIO bandwidth limiting

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -191,6 +191,29 @@ zmq_library: override CXX_DEBUG := -DFILE_FORMAT=3
 zmq_library: clean pre zmq_git_build libtmio.so
 
 #**************************************
+#*  io_uring POSIX AIO support         *
+#**************************************
+iouring_library: CXX_INC += -I$(TMIO_REPO)/dep/liburing/liburing/src/include
+# --no-as-needed: every liburing call in this library is resolved via dlsym(RTLD_NEXT, ...)
+# (see MAP_OR_FAIL), not a direct symbol reference, so the default --as-needed linker
+# behavior would otherwise drop liburing.so from libtmio.so's NEEDED list entirely --
+# and then dlsym(RTLD_NEXT, ...) has nothing to find it in at runtime.
+iouring_library: CXX_LIB_FLAGS += -L$(TMIO_REPO)/dep/liburing/liburing/src -Wl,--no-as-needed -luring -Wl,-rpath,$(TMIO_REPO)/dep/liburing/liburing/src
+iouring_library: override CXX_DEBUG := -DENABLE_IOURING_TRACE=1 -DBW_LIMIT_POSIX_AIO=1
+iouring_library: clean pre iouring_git_build libtmio.so
+
+# Same as iouring_library, but also links against the custom bandwidth-limiting
+# MPICH (see docs/bandwidth_limit.md) so -DBW_LIMIT's EMPI_* externs resolve,
+# enabling actual pacing of POSIX AIO traffic (not just io_uring-backed tracing).
+# MPICXX defaults to the vendored build; override on the command line to point
+# at a different bw-limit MPICH install.
+bw_limit_iouring_library: MPICXX = $(TMIO_REPO)/dep/bw_limit_mpich/mpich-bin/bin/mpicxx
+bw_limit_iouring_library: CXX_INC += -I$(TMIO_REPO)/dep/liburing/liburing/src/include
+bw_limit_iouring_library: CXX_LIB_FLAGS += -L$(TMIO_REPO)/dep/liburing/liburing/src -Wl,--no-as-needed -luring -Wl,-rpath,$(TMIO_REPO)/dep/liburing/liburing/src
+bw_limit_iouring_library: override CXX_DEBUG := -DENABLE_IOURING_TRACE=1 -DBW_LIMIT_POSIX_AIO=1 -DBW_LIMIT
+bw_limit_iouring_library: clean pre iouring_git_build bw_limit_mpich_git_build libtmio.so
+
+#**************************************
 #*  MSGPACK support                    *
 #**************************************
 msgpack: msgpack_build run
@@ -529,3 +552,17 @@ msgpack_git_build:
 zmq_git_build:
 	chmod u+x $(TMIO_REPO)/dep/create_lib.sh
 	$(TMIO_REPO)/dep/create_lib.sh "zmq" || echo "Failed to build ZMQ"
+
+iouring_git_build:
+	chmod u+x $(TMIO_REPO)/dep/create_lib.sh
+	$(TMIO_REPO)/dep/create_lib.sh "liburing" || echo "Failed to build liburing"
+
+# Unlike the other *_git_build targets, this skips the rebuild if the custom
+# mpicxx already exists: compilar.sh does a full `make clean` + reconfigure +
+# rebuild of MPICH every time it runs (tens of minutes), so re-triggering it
+# on every `make bw_limit_iouring_library` would make the target unusable.
+# Remove dep/bw_limit_mpich/mpich-bin to force a rebuild.
+bw_limit_mpich_git_build:
+	chmod u+x $(TMIO_REPO)/dep/create_lib.sh
+	test -x $(TMIO_REPO)/dep/bw_limit_mpich/mpich-bin/bin/mpicxx || \
+		$(TMIO_REPO)/dep/create_lib.sh "bw_limit_mpich" || echo "Failed to build bw-limit MPICH"

--- a/dep/create_lib.sh
+++ b/dep/create_lib.sh
@@ -63,6 +63,61 @@ zmq_build (){
 }
 #######################################
 
+############# liburing ######################
+# create git
+liburing () {
+	if [ ! -d "${DIR}/${FUNCNAME[0]}" ]; then
+		mkdir -p ${DIR}/${FUNCNAME[0]}
+		git clone "https://github.com/axboe/liburing.git" "${DIR}/${FUNCNAME[0]}/liburing"
+	else
+		echo "git already exists:"${DIR}/${FUNCNAME[0]}/liburing""
+	fi
+}
+
+
+liburing_build (){
+	cd ${DIR}/liburing/liburing
+	./configure ; make
+	# `-luring` needs an unversioned `liburing.so` to link against, and the
+	# runtime loader looks for the file named after the embedded SONAME
+	# (liburing.so.2) inside our RUNPATH -- a bare build only produces the
+	# fully-versioned file (liburing.so.2.15). Normally `make install` adds
+	# both symlinks, but that installs system-wide, which we don't want for
+	# a vendored dependency. Without the SONAME symlink specifically, the
+	# loader silently falls back to any system-installed liburing instead.
+	( cd src && \
+		full_so=$(ls liburing.so.*.* | head -1) && \
+		soname=$(readelf -d "$full_so" | sed -n 's/.*Library soname: \[\(.*\)\]/\1/p') && \
+		ln -sf "$full_so" liburing.so && \
+		ln -sf "$full_so" "$soname" )
+	echo "Successfully created ${FUNCNAME[0]}"
+}
+#######################################
+
+############# bw_limit_mpich ######################
+# Custom MPICH 4.0.3 with an I/O bandwidth-limiting patch in its ROMIO ufs
+# ADIO driver (chunked usleep() pacing driven by the same EMPI_DESIRED_BW_*
+# globals Bw_limit writes to -- see include/bw_limit.h). Needed to build with
+# -DBW_LIMIT / -DCUSTOM_MPI (see docs/bandwidth_limit.md).
+bw_limit_mpich () {
+	if [ ! -d "${DIR}/${FUNCNAME[0]}" ]; then
+		mkdir -p ${DIR}/${FUNCNAME[0]}
+		git clone "https://github.com/jfmunoz00/MPICH-IOBandwidth-Limitation.git" "${DIR}/${FUNCNAME[0]}/MPICH-IOBandwidth-Limitation"
+	else
+		echo "git already exists:"${DIR}/${FUNCNAME[0]}/MPICH-IOBandwidth-Limitation""
+	fi
+}
+
+bw_limit_mpich_build (){
+	cd ${DIR}/bw_limit_mpich/MPICH-IOBandwidth-Limitation
+	cp compilar.sh mpich-4.0.3_BW-limit/
+	chmod +x mpich-4.0.3_BW-limit/compilar.sh
+	mkdir -p ${DIR}/bw_limit_mpich/mpich-bin
+	mpich-4.0.3_BW-limit/compilar.sh $(readlink -f ${DIR}/bw_limit_mpich/mpich-bin)
+	echo "Successfully created ${FUNCNAME[0]}"
+}
+#######################################
+
 if [[ ${TARGETS} == *"msgpack"* ]]; then
 	echo "building: ${TARGETS}"
 	msgpack
@@ -71,6 +126,14 @@ elif [[ ${TARGETS} == *"zmq"* ]]; then
 	echo "building: ${TARGETS}"
 	zmq
 	zmq_build
+elif [[ ${TARGETS} == *"bw_limit_mpich"* ]]; then
+	echo "building: ${TARGETS}"
+	bw_limit_mpich
+	bw_limit_mpich_build
+elif [[ ${TARGETS} == *"liburing"* ]]; then
+	echo "building: ${TARGETS}"
+	liburing
+	liburing_build
 else
 	echo -e "${RED}No target specified${BLACK}"
 fi

--- a/docs/bandwidth_limit.md
+++ b/docs/bandwidth_limit.md
@@ -50,3 +50,13 @@ Run the example with the following command:
 ```
 make run_limit CXX_DEBUG+="-DBW_LIMIT_STRATEGY=2 -DBW_LIMIT_GRANULARITY=1"
 ```
+
+## POSIX AIO bandwidth limiting
+`BW_LIMIT_POSIX_AIO=1` (see `include/ioflags.h`) reimplements `aio_write`/`aio_read`/`aio_error`/`aio_return`/`aio_suspend`/`lio_listio`/`aio_cancel` on top of TMIO's own `io_uring` instance instead of glibc's AIO, so submissions/completions become a point to pace against. Build and run it with:
+```sh
+make bw_limit_iouring_library   # links against the custom MPICH above; MPICXX defaults to dep/bw_limit_mpich/mpich-bin/bin/mpicxx
+HWLOC_COMPONENTS=-gl LD_PRELOAD=./libtmio.so /path/to/mpi-bin/bin/mpirun -launcher fork -n 1 ./your_app
+```
+`-launcher fork` avoids needing a local `sshd` (this MPICH's `mpirun` defaults to ssh even for a local job). `HWLOC_COMPONENTS=-gl` avoids `MPI_Init` hanging in `hwloc`'s GL/X11 GPU-topology probe on a machine with a live X/Wayland session.
+
+`BW_LIMIT_LAYER` (`include/ioflags.h`) picks which layer paces MPI-IO-driven POSIX traffic (MPI's ROMIO patch vs. this POSIX layer) so the two don't double-pace; POSIX AIO with no MPI-IO in its call chain always paces here regardless of the setting. `lio_listio`'s `sevp` (SIGEV_* completion notification) is not supported under this backend and is silently ignored — glibc's own async completion signals need its native AIO thread pool, which this path deliberately bypasses.

--- a/docs/libc.md
+++ b/docs/libc.md
@@ -74,6 +74,7 @@ TMIO intercepts the following POSIX functions:
 *   `lio_listio`, `lio_listio64` (Batch)
 *   `aio_error`, `aio_return` (Completion monitoring)
 *   `aio_suspend` (Waiting)
+*   `aio_cancel`, `aio_cancel64` (Cancellation; passthrough by default, `io_uring`-backed under `BW_LIMIT_POSIX_AIO`, see [Bandwidth Limiting](bandwidth_limit.md))
 
 ---
 

--- a/include/interfaces/iouring_interface.h
+++ b/include/interfaces/iouring_interface.h
@@ -3,5 +3,15 @@
 #include "tmio.h"
 #if ENABLE_IOURING_TRACE == 1
 IOtraceIOuring &get_iouring_iotrace(); // allows to access iotrace in application code
+
+#if BW_LIMIT_POSIX_AIO == 1
+// Untraced access to the real io_uring_queue_init, for TMIO's own internal
+// io_uring usage (POSIX AIO emulation in libc_interface.cxx). That ring must
+// never be handed to Register_Ring: it doesn't represent an application-level
+// io_uring the app is directly responsible for, and registering it would make
+// the io_uring tracer double-count transactions already reported by
+// get_libc_iotrace() as POSIX Async I/O.
+int tmio_real_io_uring_queue_init(unsigned entries, struct io_uring *ring, unsigned flags);
+#endif
 #endif
 #endif // IOURING_INTERFACE_H

--- a/include/ioflags.h
+++ b/include/ioflags.h
@@ -21,6 +21,16 @@
 // 1: enable tracing
 #endif
 
+// Reimplements POSIX aio_read/aio_write/lio_listio on top of TMIO's own
+// io_uring instance instead of passing them through to glibc's AIO. Needed
+// so POSIX async I/O can be bandwidth-limited (glibc's AIO worker threads
+// give no observable submission/completion point to pace against).
+// Requires ENABLE_IOURING_TRACE=1 and linking against liburing (see
+// build/Makefile's iouring_library target).
+#ifndef BW_LIMIT_POSIX_AIO
+#define BW_LIMIT_POSIX_AIO 0 // set to 1 to enable
+#endif
+
 //* DEBUG Flags
 //*******************************
 #ifndef DEBUG 
@@ -235,6 +245,15 @@ constexpr VerbosityLevel BW_LIMIT_VERBOSITY = static_cast<VerbosityLevel>(BW_LIM
 
 #ifndef BW_LIMIT_FREQ
 #define BW_LIMIT_FREQ 0
+#endif
+
+// ROMIO's ufs ADIO driver calls down into POSIX pwrite/pread to service
+// MPI-IO. When BW_LIMIT_POSIX_AIO is also enabled, both layers can see the
+// same bytes; this picks which one actually paces them so they don't stack.
+// Transactions with no MPI-IO in their call chain always pace at the POSIX
+// layer regardless of this setting (see tmio::in_mpi_io_call).
+#ifndef BW_LIMIT_LAYER
+#define BW_LIMIT_LAYER 0 // 0: MPI paces MPI-IO traffic (default) -- 1: POSIX paces it
 #endif
 
 // Tolerance value to scale the desired values

--- a/include/tmio_helper_functions.h
+++ b/include/tmio_helper_functions.h
@@ -52,6 +52,27 @@
         }                                                                \
     }
 #endif
+namespace tmio
+{
+    // Set for the duration of an MPI-IO data call (MPI_File_{read,write,iread,iwrite}*),
+    // so the POSIX interceptor can tag nested calls (e.g. ROMIO's ufs ADIO driver
+    // calling pwrite/pread internally) instead of mistaking them for direct
+    // application POSIX I/O. Tracing stays on either way; only bandwidth-limit
+    // pacing decisions read this flag (see BW_LIMIT_LAYER).
+    // NOTE: only visible on the calling thread. MPI-IO actually transferred on a
+    // modified-MPICH-spawned worker thread (true async execution) is not tagged.
+    inline thread_local bool in_mpi_io_call = false;
+
+    class MPIIOCallGuard
+    {
+    public:
+        MPIIOCallGuard() { in_mpi_io_call = true; }
+        ~MPIIOCallGuard() { in_mpi_io_call = false; }
+        MPIIOCallGuard(const MPIIOCallGuard &) = delete;
+        MPIIOCallGuard &operator=(const MPIIOCallGuard &) = delete;
+    };
+}
+
 //! debug
 void Function_Debug(std::string function_name, int flag = 0);
 

--- a/src/interfaces/iouring_interface.cxx
+++ b/src/interfaces/iouring_interface.cxx
@@ -170,4 +170,13 @@ unsigned TMIO_DECL(io_uring_peek_batch_cqe)(struct io_uring *ring, struct io_uri
     return ret;
 }
 
+#if BW_LIMIT_POSIX_AIO == 1
+// See declaration comment in include/interfaces/iouring_interface.h.
+int tmio_real_io_uring_queue_init(unsigned entries, struct io_uring *ring, unsigned flags)
+{
+    MAP_OR_FAIL(io_uring_queue_init);
+    return __real_io_uring_queue_init(entries, ring, flags);
+}
+#endif
+
 #endif // ENABLE_IOURING_TRACE == 1

--- a/src/interfaces/libc_interface.cxx
+++ b/src/interfaces/libc_interface.cxx
@@ -52,12 +52,450 @@ TMIO_FORWARD_DECL(aio_read64, int, (struct aiocb64 * aiocbp));
 TMIO_FORWARD_DECL(aio_write, int, (struct aiocb * aiocbp));
 TMIO_FORWARD_DECL(aio_write64, int, (struct aiocb64 * aiocbp));
 TMIO_FORWARD_DECL(aio_error, int, (const struct aiocb *aiocbp));
+TMIO_FORWARD_DECL(aio_cancel, int, (int fd, struct aiocb *aiocbp));
+TMIO_FORWARD_DECL(aio_cancel64, int, (int fd, struct aiocb64 *aiocbp));
 // `restrict` said cannot be multiple pointer to the same object, but C++ does not support `restrict` keyword, so we use `__restrict__`
 TMIO_FORWARD_DECL(aio_suspend, int, (const struct aiocb *const aiocb_list[], int n, const struct timespec *__restrict__ timeout));
 TMIO_FORWARD_DECL(aio_return, ssize_t, (struct aiocb * aiocbp));
 TMIO_FORWARD_DECL(aio_return64, ssize_t, (struct aiocb64 * aiocbp));
 TMIO_FORWARD_DECL(lio_listio, int, (int mode, struct aiocb *const aiocb_list[], int nitems, struct sigevent *sevp));
 TMIO_FORWARD_DECL(lio_listio64, int, (int mode, struct aiocb64 *const aiocb_list[], int nitems, struct sigevent *sevp));
+
+#if BW_LIMIT_POSIX_AIO == 1
+#include "interfaces/iouring_interface.h"
+#include <liburing.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+// Reimplements POSIX AIO (aio_write/aio_read/aio_error/aio_return/aio_suspend/
+// lio_listio) on top of TMIO's own io_uring instance instead of glibc's AIO,
+// so submissions/completions become observable points to bandwidth-limit
+// against (see ioflags.h's BW_LIMIT_POSIX_AIO comment). Tracing keeps using
+// get_libc_iotrace() exactly as before (unchanged call sites below); this
+// namespace only replaces *how* the bytes actually move.
+//
+// The ring here is deliberately never registered with the io_uring tracer
+// (get_iouring_iotrace()/Register_Ring, see tmio_real_io_uring_queue_init):
+// it's an implementation detail of POSIX AIO emulation, not an
+// application-level io_uring the app is directly responsible for. Registering
+// it would make get_iouring_iotrace() double-count transactions already
+// reported here via get_libc_iotrace().
+#ifdef BW_LIMIT
+// EMPI_DESIRED_BW_I{WRITE,READ}: the same globals Bw_limit writes to and the
+// bw-limit MPICH's ROMIO patch reads (see include/bw_limit.h and
+// dep/bw_limit_mpich/.../async_io_funcs.c). Only declared/used when linked
+// against that MPICH build (docs/bandwidth_limit.md). Declared at file scope,
+// matching bw_limit.cxx's own convention for these externs -- inside a
+// namespace, C++ name-mangles the declaration and it no longer matches the
+// plain C symbol these globals actually have.
+extern long double EMPI_DESIRED_BW_IWRITE;
+extern long double EMPI_DESIRED_BW_IREAD;
+#endif
+
+namespace tmio_posix_aio
+{
+    struct CompletionState
+    {
+        bool done = false;
+        int res = 0; // >=0: bytes transferred; <0: -errno
+    };
+
+#ifdef BW_LIMIT
+    struct SubmitMeta
+    {
+        double submit_time;
+        bool is_write;
+    };
+#endif
+
+    // NOTE: thread_local, same limitation as tmio::in_mpi_io_call (see
+    // tmio_helper_functions.h): an aiocb submitted on one thread cannot be
+    // waited on / queried for completion from another thread.
+    struct RingContext
+    {
+        struct io_uring ring{};
+        bool initialized = false;
+        std::unordered_map<const struct aiocb *, CompletionState> completions;
+        std::unordered_set<struct aiocb *> pending; // submitted, not yet completed -- for aio_cancel
+#ifdef BW_LIMIT
+        std::unordered_map<const struct aiocb *, SubmitMeta> submit_meta;
+#endif
+
+        ~RingContext()
+        {
+            if (initialized)
+                io_uring_queue_exit(&ring);
+        }
+    };
+
+    inline thread_local RingContext ring_ctx;
+
+    inline void ensure_ring_initialized()
+    {
+        if (ring_ctx.initialized)
+            return;
+        int rc = tmio_real_io_uring_queue_init(64, &ring_ctx.ring, 0);
+        if (rc < 0)
+        {
+            fprintf(stderr, "TMIO > failed to initialize io_uring for POSIX AIO emulation: %s\n", strerror(-rc));
+            exit(1);
+        }
+        ring_ctx.initialized = true;
+    }
+
+#ifdef BW_LIMIT
+    // Mirrors the reference bw-limit MPICH's ROMIO patch (async_io_funcs.c's
+    // WriteContig/ReadContig): let the transfer run at full speed, then sleep
+    // out the remainder of the target duration before the completion becomes
+    // observable to aio_error/aio_return/aio_suspend.
+    // ponytail: unlike the reference, there's no time_excess carry-over
+    // between requests to compensate a slow request with a shorter sleep on
+    // the next one -- each request is paced independently. Upgrade if bursty
+    // completions show a systematic overshoot above the target bandwidth.
+    inline void pace_on_completion(const struct aiocb *aiocbp, int res)
+    {
+        if (res < 0)
+            return; // failed transfer; nothing meaningful to pace
+
+        auto it = ring_ctx.submit_meta.find(aiocbp);
+        if (it == ring_ctx.submit_meta.end())
+            return;
+        double submit_time = it->second.submit_time;
+        bool is_write = it->second.is_write;
+        ring_ctx.submit_meta.erase(it);
+
+        // Transactions with no MPI-IO in their call chain always pace here
+        // regardless of BW_LIMIT_LAYER; only skip when MPI-IO's own ROMIO
+        // patch already paced this one (see ioflags.h's BW_LIMIT_LAYER doc).
+        if (tmio::in_mpi_io_call && BW_LIMIT_LAYER == 0)
+            return;
+
+        long double desired_bw = is_write ? EMPI_DESIRED_BW_IWRITE : EMPI_DESIRED_BW_IREAD;
+        if (desired_bw <= 0.0L)
+            return;
+
+        double run_time = MPI_Wtime() - submit_time;
+        double target_time = static_cast<double>(res) / static_cast<double>(desired_bw);
+        double remaining = target_time - run_time;
+        if (remaining > 0.0)
+            usleep(static_cast<useconds_t>(remaining * 1'000'000.0));
+    }
+#endif
+
+    // Records one io_uring completion: pace it (BW_LIMIT builds only), refresh
+    // Bw_limit's next-round bandwidth target, then make it observable via
+    // ring_ctx.completions.
+    inline void record_completion(struct io_uring_cqe *cqe)
+    {
+        auto *aiocbp = reinterpret_cast<struct aiocb *>(io_uring_cqe_get_data(cqe));
+        int res = cqe->res;
+        io_uring_cqe_seen(&ring_ctx.ring, cqe);
+
+        ring_ctx.pending.erase(aiocbp);
+
+#ifdef BW_LIMIT
+        pace_on_completion(aiocbp, res);
+#endif
+
+        ring_ctx.completions[aiocbp] = {true, res};
+
+#if BW_LIMIT_GRANULARITY == 1
+        get_libc_iotrace().apply_bw_limit();
+#elif defined CUSTOM_MPI
+        get_libc_iotrace().set_custom_throughput();
+#endif
+    }
+
+    // Records every ready completion (if any) without blocking.
+    inline void drain_ready_completions()
+    {
+        struct io_uring_cqe *cqe;
+        while (io_uring_peek_cqe(&ring_ctx.ring, &cqe) == 0)
+            record_completion(cqe);
+    }
+
+    // Submits one aiocb as a single io_uring read or write SQE. Mirrors
+    // aio_write/aio_read's return contract: 0 on successful enqueue, -1/errno
+    // on failure.
+    inline int submit_one(struct aiocb *aiocbp, bool is_write)
+    {
+        ensure_ring_initialized();
+
+        struct io_uring_sqe *sqe = io_uring_get_sqe(&ring_ctx.ring);
+        if (!sqe)
+        {
+            drain_ready_completions();
+            sqe = io_uring_get_sqe(&ring_ctx.ring);
+            if (!sqe)
+            {
+                errno = EAGAIN;
+                return -1;
+            }
+        }
+
+        void *buf = const_cast<void *>(aiocbp->aio_buf);
+        if (is_write)
+            io_uring_prep_write(sqe, aiocbp->aio_fildes, buf, static_cast<unsigned>(aiocbp->aio_nbytes), static_cast<__u64>(aiocbp->aio_offset));
+        else
+            io_uring_prep_read(sqe, aiocbp->aio_fildes, buf, static_cast<unsigned>(aiocbp->aio_nbytes), static_cast<__u64>(aiocbp->aio_offset));
+
+        io_uring_sqe_set_data(sqe, aiocbp);
+        ring_ctx.completions.erase(aiocbp); // Fresh request; drop any stale prior completion.
+
+        int rc = io_uring_submit(&ring_ctx.ring);
+        if (rc < 0)
+        {
+            errno = -rc;
+            return -1;
+        }
+        ring_ctx.pending.insert(aiocbp);
+#ifdef BW_LIMIT
+        ring_ctx.submit_meta[aiocbp] = {MPI_Wtime(), is_write};
+#endif
+        return 0;
+    }
+
+    // Returns EINPROGRESS, 0 (success), or a positive errno, matching aio_error's contract.
+    inline int error_of(const struct aiocb *aiocbp)
+    {
+        drain_ready_completions();
+        auto it = ring_ctx.completions.find(aiocbp);
+        if (it == ring_ctx.completions.end() || !it->second.done)
+            return EINPROGRESS;
+        return it->second.res >= 0 ? 0 : -it->second.res;
+    }
+
+    // Consumes the recorded completion for aiocbp, matching aio_return's
+    // contract (bytes transferred, or -1/errno). Per POSIX, calling this
+    // again for the same aiocb before a new submission is undefined; we free
+    // the entry to bound memory instead of tracking that explicitly.
+    inline ssize_t return_of(struct aiocb *aiocbp)
+    {
+        auto it = ring_ctx.completions.find(aiocbp);
+        if (it == ring_ctx.completions.end() || !it->second.done)
+        {
+            errno = EINVAL;
+            return -1;
+        }
+        ssize_t result;
+        if (it->second.res >= 0)
+            result = it->second.res;
+        else
+        {
+            errno = -it->second.res;
+            result = -1;
+        }
+        ring_ctx.completions.erase(it);
+        return result;
+    }
+
+    // Blocks until aiocbp's completion is recorded (or a wait error occurs).
+    inline void wait_for(const struct aiocb *aiocbp)
+    {
+        ensure_ring_initialized();
+        while (!(ring_ctx.completions.count(aiocbp) && ring_ctx.completions[aiocbp].done))
+        {
+            struct io_uring_cqe *cqe = nullptr;
+            int rc = io_uring_wait_cqe(&ring_ctx.ring, &cqe);
+            if (rc < 0)
+            {
+                errno = -rc;
+                return;
+            }
+            record_completion(cqe);
+        }
+    }
+
+    // aio_suspend: blocks until at least one of `list`'s entries has completed.
+    // ponytail: a fresh io_uring_wait_cqe_timeout is re-armed on each spurious
+    // (irrelevant-completion) wakeup, so the *total* wait can overrun the
+    // caller's timeout when other unrelated requests complete first on this
+    // thread's ring. Upgrade if callers start passing multi-item lists with a
+    // tight timeout on a busy ring; today's callers wait on 1-2 items.
+    inline int suspend(const struct aiocb *const list[], int nitems, const struct timespec *timeout)
+    {
+        ensure_ring_initialized();
+
+        auto is_target = [&](const struct aiocb *p)
+        {
+            for (int i = 0; i < nitems; ++i)
+                if (list[i] == p)
+                    return true;
+            return false;
+        };
+
+        drain_ready_completions();
+        for (int i = 0; i < nitems; ++i)
+        {
+            if (list[i] && ring_ctx.completions.count(list[i]) && ring_ctx.completions[list[i]].done)
+                return 0;
+        }
+
+        struct __kernel_timespec kts;
+        if (timeout)
+        {
+            kts.tv_sec = timeout->tv_sec;
+            kts.tv_nsec = timeout->tv_nsec;
+        }
+
+        for (;;)
+        {
+            struct io_uring_cqe *cqe = nullptr;
+            int rc = timeout ? io_uring_wait_cqe_timeout(&ring_ctx.ring, &cqe, &kts)
+                              : io_uring_wait_cqe(&ring_ctx.ring, &cqe);
+
+            if (rc == -ETIME)
+            {
+                errno = EAGAIN;
+                return -1;
+            }
+            if (rc < 0)
+            {
+                errno = -rc;
+                return -1;
+            }
+
+            auto *cbp = reinterpret_cast<const struct aiocb *>(io_uring_cqe_get_data(cqe));
+            record_completion(cqe);
+
+            if (is_target(cbp))
+                return 0;
+        }
+    }
+
+    // Sentinel user_data for a cancel operation's own SQE/CQE, so
+    // record_completion() (which assumes any other user_data is an aiocb*)
+    // never sees it: cancel_one() intercepts and consumes it directly.
+    inline char cancel_op_marker;
+
+    // aio_cancel(fd, aiocbp): best-effort cancel of one specific request.
+    // Returns AIO_CANCELED, AIO_NOTCANCELED, or AIO_ALLDONE (see <aio.h>).
+    inline int cancel_one(struct aiocb *aiocbp)
+    {
+        ensure_ring_initialized();
+        drain_ready_completions();
+
+        if (ring_ctx.completions.count(aiocbp) && ring_ctx.completions[aiocbp].done)
+            return AIO_ALLDONE;
+        if (!ring_ctx.pending.count(aiocbp))
+            return AIO_ALLDONE; // never submitted on this thread's ring, or already reaped
+
+        struct io_uring_sqe *sqe = io_uring_get_sqe(&ring_ctx.ring);
+        if (!sqe)
+        {
+            errno = EAGAIN;
+            return -1;
+        }
+        io_uring_prep_cancel(sqe, aiocbp, 0);
+        io_uring_sqe_set_data(sqe, &cancel_op_marker);
+
+        int rc = io_uring_submit(&ring_ctx.ring);
+        if (rc < 0)
+        {
+            errno = -rc;
+            return -1;
+        }
+
+        // Block for the cancel op's own completion, recording any other
+        // (unrelated) completions normally along the way.
+        int cancel_res = 0;
+        for (;;)
+        {
+            struct io_uring_cqe *cqe = nullptr;
+            int wrc = io_uring_wait_cqe(&ring_ctx.ring, &cqe);
+            if (wrc < 0)
+            {
+                errno = -wrc;
+                return -1;
+            }
+            if (io_uring_cqe_get_data(cqe) == &cancel_op_marker)
+            {
+                cancel_res = cqe->res;
+                io_uring_cqe_seen(&ring_ctx.ring, cqe);
+                break;
+            }
+            record_completion(cqe);
+        }
+
+        // On success the target's own completion (res == -ECANCELED) should
+        // now be ready too; drain it so aio_error()/aio_return() see it.
+        drain_ready_completions();
+
+        if (cancel_res == 0)
+            return AIO_CANCELED;
+        if (cancel_res == -EALREADY)
+            return AIO_NOTCANCELED;
+        // -ENOENT or anything else: target wasn't found on this ring (raced
+        // with its own completion, or already reaped).
+        return ring_ctx.pending.count(aiocbp) ? AIO_NOTCANCELED : AIO_ALLDONE;
+    }
+
+    // aio_cancel(fd, NULL): best-effort cancel of every outstanding request
+    // for fd that was submitted on this thread's ring.
+    inline int cancel_all(int fd)
+    {
+        ensure_ring_initialized();
+        drain_ready_completions();
+
+        std::vector<struct aiocb *> targets;
+        for (auto *p : ring_ctx.pending)
+            if (p->aio_fildes == fd)
+                targets.push_back(p);
+
+        if (targets.empty())
+            return AIO_ALLDONE;
+
+        bool all_canceled = true;
+        for (auto *p : targets)
+            if (cancel_one(p) != AIO_CANCELED)
+                all_canceled = false;
+        return all_canceled ? AIO_CANCELED : AIO_NOTCANCELED;
+    }
+
+    // lio_listio helpers: submit every non-NOP item, and/or block until every
+    // submitted item has completed. Returns 0 if all items succeeded, else -1
+    // with errno set to the first failure's error.
+    inline int submit_batch(struct aiocb *const list[], int nitems)
+    {
+        int first_errno = 0;
+        for (int i = 0; i < nitems; ++i)
+        {
+            if (!list[i] || list[i]->aio_lio_opcode == LIO_NOP)
+                continue;
+            bool is_write = (list[i]->aio_lio_opcode == LIO_WRITE);
+            if (submit_one(list[i], is_write) != 0 && !first_errno)
+                first_errno = errno;
+        }
+        if (first_errno)
+        {
+            errno = first_errno;
+            return -1;
+        }
+        return 0;
+    }
+
+    inline int wait_batch(struct aiocb *const list[], int nitems)
+    {
+        int first_errno = 0;
+        for (int i = 0; i < nitems; ++i)
+        {
+            if (!list[i] || list[i]->aio_lio_opcode == LIO_NOP)
+                continue;
+            wait_for(list[i]);
+            auto it = ring_ctx.completions.find(list[i]);
+            if (it != ring_ctx.completions.end() && it->second.res < 0 && !first_errno)
+                first_errno = -it->second.res;
+        }
+        if (first_errno)
+        {
+            errno = first_errno;
+            return -1;
+        }
+        return 0;
+    }
+} // namespace tmio_posix_aio
+#endif // BW_LIMIT_POSIX_AIO
 
 TMIO_FORWARD_DECL(read, ssize_t, (int fd, void *buf, size_t count));
 TMIO_FORWARD_DECL(write, ssize_t, (int fd, const void *buf, size_t count));
@@ -229,10 +667,13 @@ int TMIO_DECL(aio_write)(struct aiocb *aiocbp)
 	Function_Debug(function_name);
 	int ret;
 
-	MAP_OR_FAIL(aio_write);
-
 	get_libc_iotrace().Write_Async_Start(aiocbp);
+#if BW_LIMIT_POSIX_AIO == 1
+	ret = tmio_posix_aio::submit_one(aiocbp, true);
+#else
+	MAP_OR_FAIL(aio_write);
 	ret = __real_aio_write(aiocbp);
+#endif
 	return (ret);
 }
 
@@ -241,10 +682,13 @@ int TMIO_DECL(aio_write64)(struct aiocb64 *aiocbp)
 	Function_Debug(__PRETTY_FUNCTION__);
 	int ret;
 
-	MAP_OR_FAIL(aio_write64);
-
 	get_libc_iotrace().Write_Async_Start(aiocbp);
+#if BW_LIMIT_POSIX_AIO == 1
+	ret = tmio_posix_aio::submit_one(reinterpret_cast<struct aiocb *>(aiocbp), true);
+#else
+	MAP_OR_FAIL(aio_write64);
 	ret = __real_aio_write64(aiocbp);
+#endif
 	return (ret);
 }
 
@@ -254,10 +698,13 @@ int TMIO_DECL(aio_read)(struct aiocb *aiocbp)
 	Function_Debug(__PRETTY_FUNCTION__);
 	int ret;
 
-	MAP_OR_FAIL(aio_read);
-
 	get_libc_iotrace().Read_Async_Start(aiocbp);
+#if BW_LIMIT_POSIX_AIO == 1
+	ret = tmio_posix_aio::submit_one(aiocbp, false);
+#else
+	MAP_OR_FAIL(aio_read);
 	ret = __real_aio_read(aiocbp);
+#endif
 	return (ret);
 }
 
@@ -266,10 +713,13 @@ int TMIO_DECL(aio_read64)(struct aiocb64 *aiocbp)
 	Function_Debug(__PRETTY_FUNCTION__);
 	int ret;
 
-	MAP_OR_FAIL(aio_read64);
-
 	get_libc_iotrace().Read_Async_Start(aiocbp);
+#if BW_LIMIT_POSIX_AIO == 1
+	ret = tmio_posix_aio::submit_one(reinterpret_cast<struct aiocb *>(aiocbp), false);
+#else
+	MAP_OR_FAIL(aio_read64);
 	ret = __real_aio_read64(aiocbp);
+#endif
 	return (ret);
 }
 
@@ -288,9 +738,12 @@ int TMIO_DECL(aio_error)(const struct aiocb *aiocbp)
 
 	int ret;
 
+#if BW_LIMIT_POSIX_AIO == 1
+	ret = tmio_posix_aio::error_of(aiocbp);
+#else
 	MAP_OR_FAIL(aio_error);
-
 	ret = __real_aio_error(aiocbp);
+#endif
 
     switch (ret)
     {
@@ -322,6 +775,35 @@ int TMIO_DECL(aio_error)(const struct aiocb *aiocbp)
 }
 
 /**
+ * @brief Cancel one (or, with aiocbp == NULL, all) outstanding AIO request(s) for a file descriptor.
+ * @return AIO_CANCELED, AIO_NOTCANCELED, or AIO_ALLDONE (see aio.h), or -1/errno on failure.
+ */
+int TMIO_DECL(aio_cancel)(int fd, struct aiocb *aiocbp)
+{
+	Function_Debug(__PRETTY_FUNCTION__);
+	int ret;
+
+#if BW_LIMIT_POSIX_AIO == 1
+	ret = aiocbp ? tmio_posix_aio::cancel_one(aiocbp) : tmio_posix_aio::cancel_all(fd);
+#else
+	MAP_OR_FAIL(aio_cancel);
+	ret = __real_aio_cancel(fd, aiocbp);
+#endif
+	return (ret);
+}
+
+int TMIO_DECL(aio_cancel64)(int fd, struct aiocb64 *aiocbp)
+{
+	Function_Debug(__PRETTY_FUNCTION__);
+#if BW_LIMIT_POSIX_AIO == 1
+	return aio_cancel(fd, reinterpret_cast<struct aiocb *>(aiocbp));
+#else
+	MAP_OR_FAIL(aio_cancel64);
+	return __real_aio_cancel64(fd, aiocbp);
+#endif
+}
+
+/**
  * @brief Record the required finished time for those AIO requests.
  * @note TMIO should treat a call to aio_suspend as an explicit indication from the user that
  * 		 they are waiting for the specified AIO requests to complete.
@@ -336,8 +818,6 @@ int TMIO_DECL(aio_suspend)(const struct aiocb *const aiocb_list[], int nitems, c
 	Function_Debug(__PRETTY_FUNCTION__);
 	int ret;
 
-	MAP_OR_FAIL(aio_suspend);
-
 	for (int i = 0; i < nitems; ++i)
 	{
 		if (aiocb_list[i] != nullptr)
@@ -346,7 +826,12 @@ int TMIO_DECL(aio_suspend)(const struct aiocb *const aiocb_list[], int nitems, c
 			get_libc_iotrace().Write_Async_Required(aiocb_list[i]);
 		}
 	}
+#if BW_LIMIT_POSIX_AIO == 1
+	ret = tmio_posix_aio::suspend(aiocb_list, nitems, timeout);
+#else
+	MAP_OR_FAIL(aio_suspend);
 	ret = __real_aio_suspend(aiocb_list, nitems, timeout);
+#endif
 	return (ret);
 }
 
@@ -375,9 +860,12 @@ ssize_t TMIO_DECL(aio_return)(struct aiocb *aiocbp)
 	Function_Debug(__PRETTY_FUNCTION__);
 	ssize_t ret;
 
+#if BW_LIMIT_POSIX_AIO == 1
+	ret = tmio_posix_aio::return_of(aiocbp);
+#else
 	MAP_OR_FAIL(aio_return);
-
 	ret = __real_aio_return(aiocbp);
+#endif
 
 	if (ret != -1) // If success, trace
 	{
@@ -449,7 +937,13 @@ int TMIO_DECL(lio_listio)(int mode, struct aiocb *const aiocb_list[], int nitems
 
 #endif
 
+#if BW_LIMIT_POSIX_AIO == 1
+		ret = tmio_posix_aio::submit_batch(aiocb_list, nitems);
+		if (ret == 0)
+			ret = tmio_posix_aio::wait_batch(aiocb_list, nitems);
+#else
 		ret = __real_lio_listio(mode, aiocb_list, nitems, sevp);
+#endif
 
 		if (ret != 0)
 			std::cerr << "TMIO > lio_listio(LIO_WAIT) failed or interrupted: " << strerror(errno) << " (errno=" << errno << "). TMIO tracing result might be inaccurate. Better to call the lio_list again" << std::endl;
@@ -486,7 +980,11 @@ int TMIO_DECL(lio_listio)(int mode, struct aiocb *const aiocb_list[], int nitems
 			}
 		}
 
+#if BW_LIMIT_POSIX_AIO == 1
+		ret = tmio_posix_aio::submit_batch(aiocb_list, nitems);
+#else
 		ret = __real_lio_listio(mode, aiocb_list, nitems, sevp);
+#endif
 
 		// We cannot use aio_err to check each request.
 		// If we use it to check a non-initialized aiocb, it would return the same result as success call.
@@ -503,99 +1001,9 @@ int TMIO_DECL(lio_listio64)(int mode, struct aiocb64 *const aiocb_list[], int ni
 {
 	Function_Debug(__PRETTY_FUNCTION__);
 
-	ssize_t ret;
-	MAP_OR_FAIL(lio_listio);
-
-	if (mode == LIO_WAIT) // Sync
-	{
-#if BATCH_LIO == 1
-		// Merge all aiocb into one overarching request, but only for tracing
-		int batch_read_iovcnt = 0;
-		int batch_write_iovcnt = 0;
-		const static int OFFSET = INT32_MAX; // Use a large offset to avoid conflicts
-
-		for (int i = 0; i < nitems; ++i)
-		{
-			if (aiocb_list[i] != nullptr)
-			{
-				if (aiocb_list[i]->aio_lio_opcode == LIO_READ)
-					batch_read_iovcnt += aiocb_list[i]->aio_nbytes;
-				else if (aiocb_list[i]->aio_lio_opcode == LIO_WRITE)
-					batch_write_iovcnt += aiocb_list[i]->aio_nbytes;
-				else
-					continue; // LIO_NOP
-			}
-		}
-
-		if (batch_read_iovcnt > 0)
-			get_libc_iotrace().Read_Sync_Start(batch_read_iovcnt, OFFSET);
-
-		if (batch_write_iovcnt > 0)
-			get_libc_iotrace().Write_Sync_Start(batch_write_iovcnt, OFFSET);
-#else
-		for (int i = 0; i < nitems; ++i)
-		{
-			if (aiocb_list[i] != nullptr)
-			{
-				if (aiocb_list[i]->aio_lio_opcode == LIO_READ)
-					get_libc_iotrace().Read_Sync_Start(aiocb_list[i]->aio_nbytes, aiocb_list[i]->aio_offset);
-				else if (aiocb_list[i]->aio_lio_opcode == LIO_WRITE)
-					get_libc_iotrace().Write_Sync_Start(aiocb_list[i]->aio_nbytes, aiocb_list[i]->aio_offset);
-				else
-					continue; // LIO_NOP
-			}
-		}
-
-#endif
-
-		ret = __real_lio_listio64(mode, aiocb_list, nitems, sevp);
-
-		if (ret != 0)
-			std::cerr << "TMIO > lio_listio(LIO_WAIT) failed or interrupted: " << strerror(errno) << " (errno=" << errno << "). TMIO tracing result might be inaccurate. Better to call the lio_list again" << std::endl;
-
-// End the sync tracing
-#if BATCH_LIO == 1
-		if (batch_read_iovcnt > 0)
-			get_libc_iotrace().Read_Sync_End();
-		if (batch_write_iovcnt > 0)
-			get_libc_iotrace().Write_Sync_End();
-#else
-		for (int i = 0; i < nitems; ++i)
-		{
-			if (aiocb_list[i] != nullptr)
-			{
-				if (aiocb_list[i]->aio_lio_opcode == LIO_READ)
-					get_libc_iotrace().Read_Sync_End();
-				else if (aiocb_list[i]->aio_lio_opcode == LIO_WRITE)
-					get_libc_iotrace().Write_Sync_End();
-				else
-					continue; // LIO_NOP
-			}
-		}
-#endif
-	}
-	else if (mode == LIO_NOWAIT)
-	{
-		for (int i = 0; i < nitems; ++i)
-		{
-			if (aiocb_list[i] != nullptr)
-			{
-				get_libc_iotrace().Read_Async_Start(aiocb_list[i]);
-				get_libc_iotrace().Write_Async_Start(aiocb_list[i]);
-			}
-		}
-
-		ret = __real_lio_listio64(mode, aiocb_list, nitems, sevp);
-
-		// We cannot use aio_err to check each request.
-		// If we use it to check a non-initialized aiocb, it would return the same result as success call.
-		if (ret != 0)
-			std::cerr << "TMIO > lio_listio(LIO_NOWAIT) failed: " << strerror(errno) << " (errno=" << errno << "). TMIO tracing result might be inaccurate. Better to call the lio_list again" << std::endl;
-	} else
-	{
-		std::cerr << "TMIO > lio_listio: unsupported mode: " << mode << ". Only LIO_WAIT and LIO_NOWAIT are supported." << std::endl;
-	}
-	return (ret);
+	// aiocb and aiocb64 share layout on 64-bit Linux (see aio_return64/aio_suspend64
+	// above, which rely on the same assumption).
+	return lio_listio(mode, reinterpret_cast<struct aiocb *const *>(aiocb_list), nitems, sevp);
 }
 //! ----------------------- Sync Read & Write ------------------------------
 

--- a/src/interfaces/mpi_interface.cxx
+++ b/src/interfaces/mpi_interface.cxx
@@ -90,6 +90,7 @@ int MPI_File_close(MPI_File *fh)
 int MPI_File_iwrite(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 	MPI_Offset offset = 0;
 #ifdef TOTAL_OFFSET
 	MPI_File_get_position(fh, &offset);
@@ -107,6 +108,7 @@ int MPI_File_iwrite(MPI_File fh, const void *buf, int count, MPI_Datatype dataty
 int MPI_File_iwrite_at(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 #if BW_LIMIT_GRANULARITY > 1
 	mpi_iotrace.apply_file_specific_bw(true, fh, count, datatype);
 #endif
@@ -120,6 +122,7 @@ int MPI_File_iwrite_at(MPI_File fh, MPI_Offset offset, const void *buf, int coun
 int MPI_File_iwrite_all(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 	MPI_Offset offset = 0;
 #ifdef TOTAL_OFFSET
 	MPI_File_get_position(fh, &offset);
@@ -134,6 +137,7 @@ int MPI_File_iwrite_all(MPI_File fh, const void *buf, int count, MPI_Datatype da
 int MPI_File_iwrite_at_all(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 	mpi_iotrace.Write_Async_Start(count / mpi_iotrace.Get_Relevant_Ranks(fh), datatype, request, fh, offset);
 	return PMPI_File_iwrite_at_all(fh, offset, buf, count, datatype, request);
 }
@@ -144,6 +148,7 @@ int MPI_File_iwrite_at_all(MPI_File fh, MPI_Offset offset, const void *buf, int 
 int MPI_File_iwrite_shared(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 	MPI_Offset offset = 0;
 #ifdef TOTAL_OFFSET
 	MPI_File_get_position_shared(fh, &offset);
@@ -163,6 +168,7 @@ int MPI_File_iwrite_shared(MPI_File fh, const void *buf, int count, MPI_Datatype
 int MPI_File_write(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 	MPI_Offset offset = 0;
 #ifdef TOTAL_OFFSET
 	MPI_File_get_position(fh, &offset);
@@ -179,6 +185,7 @@ int MPI_File_write(MPI_File fh, const void *buf, int count, MPI_Datatype datatyp
 int MPI_File_write_at(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 	mpi_iotrace.Write_Sync_Start(count, datatype, offset);
 	int result = PMPI_File_write_at(fh, offset, buf, count, datatype, status);
 	mpi_iotrace.Write_Sync_End();
@@ -191,6 +198,7 @@ int MPI_File_write_at(MPI_File fh, MPI_Offset offset, const void *buf, int count
 int MPI_File_write_all(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 	MPI_Offset offset = 0;
 #ifdef TOTAL_OFFSET
 	MPI_File_get_position(fh, &offset);
@@ -207,6 +215,7 @@ int MPI_File_write_all(MPI_File fh, const void *buf, int count, MPI_Datatype dat
 int MPI_File_write_at_all(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 	mpi_iotrace.Write_Sync_Start(count / mpi_iotrace.Get_Relevant_Ranks(fh), datatype, offset);
 	int result = PMPI_File_write_at_all(fh, offset, buf, count, datatype, status);
 	mpi_iotrace.Write_Sync_End();
@@ -219,6 +228,7 @@ int MPI_File_write_at_all(MPI_File fh, MPI_Offset offset, const void *buf, int c
 int MPI_File_write_shared(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 	MPI_Offset offset = 0;
 #ifdef TOTAL_OFFSET
 	MPI_File_get_position_shared(fh, &offset);
@@ -237,6 +247,7 @@ int MPI_File_write_shared(MPI_File fh, const void *buf, int count, MPI_Datatype 
 int MPI_File_iread(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Request *request)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 #ifdef PREFETCH
 	CallSignature cs = 
 		CallSignature(fh, count, datatype, 0, CallSignature::CallType::Read);
@@ -260,6 +271,7 @@ int MPI_File_iread(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI
 int MPI_File_iread_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Request *request)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 #ifdef PREFETCH
 	CallSignature cs = 
 		CallSignature(fh, count, datatype, offset, CallSignature::CallType::ReadAt);
@@ -279,6 +291,7 @@ int MPI_File_iread_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_
 int MPI_File_iread_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Request *request)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 	MPI_Offset offset = 0;
 #ifdef TOTAL_OFFSET
 	MPI_File_get_position(fh, &offset);
@@ -293,6 +306,7 @@ int MPI_File_iread_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype,
 int MPI_File_iread_at_all(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Request *request)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 	mpi_iotrace.Read_Async_Start(count / mpi_iotrace.Get_Relevant_Ranks(fh), datatype, request, fh, offset);
 	return PMPI_File_iread_at_all(fh, offset, buf, count, datatype, request);
 }
@@ -303,6 +317,7 @@ int MPI_File_iread_at_all(MPI_File fh, MPI_Offset offset, void *buf, int count, 
 int MPI_File_iread_shared(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Request *request)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 #if BW_LIMIT_GRANULARITY > 1
 	mpi_iotrace.apply_file_specific_bw(false, fh, count, datatype);
 #endif
@@ -322,6 +337,7 @@ int MPI_File_iread_shared(MPI_File fh, void *buf, int count, MPI_Datatype dataty
 int MPI_File_read(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 #ifdef PREFETCH
 	CallSignature cs = 
 		CallSignature(fh, count, datatype, 0, CallSignature::CallType::Read);
@@ -344,6 +360,7 @@ int MPI_File_read(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_
 int MPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Status *status)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 #ifdef PREFETCH
 	CallSignature cs = 
 		CallSignature(fh, count, datatype, offset, CallSignature::CallType::ReadAt);
@@ -362,6 +379,7 @@ int MPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_D
 int MPI_File_read_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 	MPI_Offset offset = 0;
 #ifdef TOTAL_OFFSET
 	MPI_File_get_position(fh, &offset);
@@ -378,6 +396,7 @@ int MPI_File_read_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype, 
 int MPI_File_read_at_all(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Status *status)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 	mpi_iotrace.Read_Sync_Start(count / mpi_iotrace.Get_Relevant_Ranks(fh), datatype, offset);
 	int result = PMPI_File_read_at_all(fh, offset, buf, count, datatype, status);
 	mpi_iotrace.Read_Sync_End();
@@ -390,6 +409,7 @@ int MPI_File_read_at_all(MPI_File fh, MPI_Offset offset, void *buf, int count, M
 int MPI_File_read_shared(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status)
 {
 	Function_Debug(__PRETTY_FUNCTION__);
+	tmio::MPIIOCallGuard mpi_io_call_guard;
 	MPI_Offset offset = 0;
 #ifdef TOTAL_OFFSET
 	MPI_File_get_position_shared(fh, &offset);

--- a/src/iotraces/iotrace_base.cxx
+++ b/src/iotraces/iotrace_base.cxx
@@ -1,4 +1,5 @@
 #include "iotrace.h"
+#include <type_traits>
 
 /**
  * @file iotrace.cpp
@@ -313,6 +314,10 @@ void IOtraceBase<Tag>::Write_Async_Start_Impl(RequestIDType requestID, long long
     IOtraceBase<Tag>::Log<VerbosityLevel::DEBUG_LOG>(
         "%s > rank %i %s>>> has offset %lli %s\n", caller, rank, YELLOW, offset,
         BLACK);
+    if constexpr (!std::is_same_v<Tag, MPI_Tag>)
+        if (tmio::in_mpi_io_call)
+            IOtraceBase<Tag>::Log<VerbosityLevel::BASIC_LOG>(
+                "%s > rank %i > invoked_from: MPI-IO call (nested POSIX transaction)\n", caller, rank);
     Overhead_End();
 }
 
@@ -424,6 +429,10 @@ void IOtraceBase<Tag>::Read_Async_Start_Impl(RequestIDType requestID, long long 
     IOtraceBase<Tag>::Log<VerbosityLevel::DEBUG_LOG>(
         "%s > rank %i %s>>> has offset %lli %s\n", caller, rank, YELLOW, offset,
         BLACK);
+    if constexpr (!std::is_same_v<Tag, MPI_Tag>)
+        if (tmio::in_mpi_io_call)
+            IOtraceBase<Tag>::Log<VerbosityLevel::BASIC_LOG>(
+                "%s > rank %i > invoked_from: MPI-IO call (nested POSIX transaction)\n", caller, rank);
     Overhead_End();
 }
 
@@ -536,6 +545,10 @@ void IOtraceBase<Tag>::Write_Sync_Start_Impl(long long size, long long offset, d
     IOtraceBase<Tag>::Log<VerbosityLevel::DETAILED_LOG>(
         "%s > rank %i %s>> started sync write @ %.2f s %s\n", caller, rank,
         GREEN, t_sync_write_start, BLACK);
+    if constexpr (!std::is_same_v<Tag, MPI_Tag>)
+        if (tmio::in_mpi_io_call)
+            IOtraceBase<Tag>::Log<VerbosityLevel::BASIC_LOG>(
+                "%s > rank %i > invoked_from: MPI-IO call (nested POSIX transaction)\n", caller, rank);
     Overhead_End();
 }
 
@@ -585,6 +598,10 @@ void IOtraceBase<Tag>::Read_Sync_Start_Impl(long long size, long long offset, do
     IOtraceBase<Tag>::Log<VerbosityLevel::DEBUG_LOG>(
         "%s > rank %i %s>>> has offset %lli %s\n", caller, rank, YELLOW, offset,
         BLACK);
+    if constexpr (!std::is_same_v<Tag, MPI_Tag>)
+        if (tmio::in_mpi_io_call)
+            IOtraceBase<Tag>::Log<VerbosityLevel::BASIC_LOG>(
+                "%s > rank %i > invoked_from: MPI-IO call (nested POSIX transaction)\n", caller, rank);
 
     Overhead_End();
 }

--- a/test/posix_aio/run_bw_limit_test.sh
+++ b/test/posix_aio/run_bw_limit_test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Verifies TMIO's POSIX-AIO bandwidth pacing (-DBW_LIMIT, custom bw-limit
+# MPICH -- see docs/bandwidth_limit.md). Unlike run_test.sh, correctness here
+# IS the timing: an unpaced write must be fast, and a write capped at
+# 1 MiB/s must take roughly as long as its size implies (asserted inside
+# test_bw_limit.cxx).
+set -e
+
+DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT=$(readlink -f "$DIR/../..")
+BUILD="$ROOT/build"
+MPICXX="$ROOT/dep/bw_limit_mpich/mpich-bin/bin/mpicxx"
+MPIRUN="$ROOT/dep/bw_limit_mpich/mpich-bin/bin/mpirun"
+
+if [ ! -x "$MPICXX" ]; then
+    echo "FAIL: custom bw-limit MPICH not built at $MPICXX (make bw_limit_mpich_git_build first)."
+    exit 1
+fi
+
+echo "Building libtmio.so with BW_LIMIT + io_uring-backed POSIX AIO (make bw_limit_iouring_library)..."
+(cd "$BUILD" && make bw_limit_iouring_library) >/dev/null
+
+echo "Compiling test_bw_limit and test_mixed_mpi_posix..."
+"$MPICXX" -std=c++17 -o "$DIR/test_bw_limit" "$DIR/test_bw_limit.cxx"
+"$MPICXX" -std=c++17 -o "$DIR/test_mixed_mpi_posix" "$DIR/test_mixed_mpi_posix.cxx"
+
+# -launcher fork: this MPICH's mpirun defaults to an ssh-based launcher even
+# for a local single-rank job, which needs a working local sshd we can't
+# assume exists.
+# HWLOC_COMPONENTS=-gl: MPI_Init's hwloc-based topology detection loads
+# hwloc's GL plugin, which calls XOpenDisplay() to enumerate GPU topology
+# over X11. On a machine with a live X/Wayland session that connect() can
+# hang indefinitely (confirmed via gdb backtrace: MPI_Init -> ... ->
+# MPII_hwtopo_init -> hwloc_topology_load -> hwloc_gl.so -> XOpenDisplay ->
+# blocks in connect()). This isn't about bandwidth limiting or TMIO at all --
+# it reproduces with a bare MPI_Init()/MPI_Finalize() program -- so just tell
+# hwloc to skip that component.
+echo "Running test_bw_limit..."
+HWLOC_COMPONENTS=-gl LD_PRELOAD="$BUILD/libtmio.so" "$MPIRUN" -launcher fork -n 1 "$DIR/test_bw_limit"
+
+echo "Running test_mixed_mpi_posix (MPI-IO + POSIX AIO in the same process)..."
+HWLOC_COMPONENTS=-gl LD_PRELOAD="$BUILD/libtmio.so" "$MPIRUN" -launcher fork -n 1 "$DIR/test_mixed_mpi_posix"

--- a/test/posix_aio/run_test.sh
+++ b/test/posix_aio/run_test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Verifies TMIO's io_uring-backed POSIX AIO emulation (BW_LIMIT_POSIX_AIO=1):
+#   1. correctness of aio_write/aio_read/aio_suspend/aio_return/lio_listio
+#      (asserted inside test_posix_aio.cxx itself)
+#   2. that the calls actually go through io_uring rather than glibc's AIO
+#      passthrough -- correctness alone can't tell the two backends apart,
+#      since glibc's real AIO is already correct. This is checked here via
+#      strace: if no io_uring_setup/io_uring_enter syscalls show up, TMIO
+#      silently fell back to passthrough despite the flag.
+set -e
+
+DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT=$(readlink -f "$DIR/../..")
+BUILD="$ROOT/build"
+STRACE_LOG=$(mktemp)
+trap 'rm -f "$STRACE_LOG"' EXIT
+
+echo "Building libtmio.so with io_uring-backed POSIX AIO (make iouring_library)..."
+(cd "$BUILD" && make iouring_library) >/dev/null
+
+echo "Compiling test_posix_aio..."
+mpicxx -std=c++17 -o "$DIR/test_posix_aio" "$DIR/test_posix_aio.cxx"
+
+echo "Running under strace with TMIO preloaded..."
+LD_PRELOAD="$BUILD/libtmio.so" strace -f -e trace=io_uring_setup,io_uring_enter \
+    -o "$STRACE_LOG" mpirun -n 1 "$DIR/test_posix_aio"
+
+if ! grep -q "io_uring_setup\|io_uring_enter" "$STRACE_LOG"; then
+    echo "FAIL: aio_write/aio_read did not touch io_uring -- still glibc AIO passthrough."
+    echo "--- strace log ---"
+    cat "$STRACE_LOG"
+    exit 1
+fi
+
+echo "PASS: POSIX AIO calls are routed through io_uring, and roundtrip correctness holds."

--- a/test/posix_aio/test_bw_limit.cxx
+++ b/test/posix_aio/test_bw_limit.cxx
@@ -1,0 +1,90 @@
+// Verifies that TMIO's io_uring-backed POSIX AIO actually paces to
+// EMPI_DESIRED_BW_IWRITE (the same global Bw_limit writes to and the bw-limit
+// MPICH's ROMIO patch reads -- see include/bw_limit.h and
+// dep/bw_limit_mpich/.../async_io_funcs.c). Requires building with -DBW_LIMIT
+// against that custom MPICH (see test/posix_aio/run_bw_limit_test.sh).
+#include <aio.h>
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <mpi.h>
+#include <unistd.h>
+#include <vector>
+
+extern "C" long double EMPI_DESIRED_BW_IWRITE;
+
+static const char *PATH = "tmio_bw_limit_test.dat";
+static const size_t SIZE = 4 * 1024 * 1024; // 4 MiB
+
+static double write_once(std::vector<char> &buf)
+{
+    int fd = open(PATH, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    assert(fd >= 0);
+
+    struct aiocb cb = {};
+    cb.aio_fildes = fd;
+    cb.aio_buf = buf.data();
+    cb.aio_nbytes = buf.size();
+    cb.aio_offset = 0;
+
+    double t0 = MPI_Wtime();
+    assert(aio_write(&cb) == 0);
+    const struct aiocb *list[1] = {&cb};
+    assert(aio_suspend(list, 1, nullptr) == 0);
+    assert(aio_error(&cb) == 0);
+    assert(aio_return(&cb) == (ssize_t)buf.size());
+    double elapsed = MPI_Wtime() - t0;
+
+    close(fd);
+    return elapsed;
+}
+
+// Accuracy sweep: for each target bandwidth, pace a write sized so the
+// target duration is ~2s, then check the *achieved* bandwidth (bytes /
+// elapsed) is within TOLERANCE of the target -- not just "took at least N
+// seconds". Mirrors what docs/bandwidth_limit.md's T/B_L/B plotting checks
+// visually via an external example app, as a self-contained numeric check.
+static const double TOLERANCE = 0.15; // +/-15%
+
+static void test_accuracy_at(long double target_bw_bytes_per_sec)
+{
+    size_t size = static_cast<size_t>(target_bw_bytes_per_sec * 2.0L); // ~2s target
+    std::vector<char> buf(size, 'x');
+
+    EMPI_DESIRED_BW_IWRITE = target_bw_bytes_per_sec;
+    double elapsed = write_once(buf);
+    double achieved_bw = static_cast<double>(size) / elapsed;
+    double target_bw = static_cast<double>(target_bw_bytes_per_sec);
+    double rel_error = (achieved_bw - target_bw) / target_bw;
+
+    printf("target %.0f B/s: wrote %zu bytes in %.3f s -> achieved %.0f B/s (%.1f%% error)\n",
+           target_bw, size, elapsed, achieved_bw, rel_error * 100.0);
+    assert(rel_error >= -TOLERANCE && rel_error <= TOLERANCE);
+}
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+    std::vector<char> buf(SIZE, 'x');
+
+    EMPI_DESIRED_BW_IWRITE = 0.0L;
+    double unpaced = write_once(buf);
+    printf("unpaced write of %zu bytes took %.3f s\n", SIZE, unpaced);
+    assert(unpaced < 2.0); // sanity: without a cap this is fast (local disk/tmpfs)
+
+    EMPI_DESIRED_BW_IWRITE = 1.0L * 1024 * 1024; // cap at 1 MiB/s -> expect ~4s
+    double paced = write_once(buf);
+    printf("paced write of %zu bytes at 1 MiB/s took %.3f s\n", SIZE, paced);
+    assert(paced >= 3.0); // generous floor around the ~4s target to avoid flakiness
+    printf("test_bw_limit_paces_posix_aio: OK\n");
+
+    test_accuracy_at(256.0L * 1024);       // 256 KiB/s
+    test_accuracy_at(1.0L * 1024 * 1024);  // 1 MiB/s
+    test_accuracy_at(4.0L * 1024 * 1024);  // 4 MiB/s
+    printf("test_bw_limit_accuracy: OK\n");
+
+    unlink(PATH);
+    MPI_Finalize();
+    return 0;
+}

--- a/test/posix_aio/test_mixed_mpi_posix.cxx
+++ b/test/posix_aio/test_mixed_mpi_posix.cxx
@@ -1,0 +1,92 @@
+// Verifies TMIO stays sane (no crash, no hang, no corruption) when a single
+// process uses BOTH MPI-IO (MPI_File_iwrite) and direct POSIX aio_write in
+// the same run. EMPI_DESIRED_BW_IWRITE is a single process-wide global that
+// both the MPI-IO layer (via mpi_iotrace's Bw_limit) and this POSIX layer
+// (via get_libc_iotrace()'s Bw_limit, see pace_on_completion in
+// libc_interface.cxx) read/write -- this is the one thing neither
+// test_posix_aio.cxx nor test_bw_limit.cxx (POSIX-only) nor the HACC-IO
+// example (MPI-IO-only) actually exercises together.
+#include <aio.h>
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <mpi.h>
+#include <unistd.h>
+#include <vector>
+
+extern "C" long double EMPI_DESIRED_BW_IWRITE;
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+
+    // 1. MPI-IO write: drives mpi_iotrace's Bw_limit phase tracking, which
+    // calls apply_bw_limit() on MPI_Wait and updates the shared
+    // EMPI_DESIRED_BW_IWRITE global from MPI-IO's own measured throughput.
+    const char *mpi_path = "tmio_mixed_mpi.dat";
+    const char mpi_msg[] = "MPI-IO half of the mixed workload";
+    MPI_File fh;
+    assert(MPI_File_open(MPI_COMM_SELF, mpi_path, MPI_MODE_CREATE | MPI_MODE_WRONLY, MPI_INFO_NULL, &fh) == MPI_SUCCESS);
+    MPI_Request req;
+    assert(MPI_File_iwrite(fh, mpi_msg, sizeof(mpi_msg), MPI_BYTE, &req) == MPI_SUCCESS);
+    MPI_Status status;
+    assert(MPI_Wait(&req, &status) == MPI_SUCCESS);
+    assert(MPI_File_close(&fh) == MPI_SUCCESS);
+    printf("MPI-IO write: OK\n");
+
+    // The MPI-IO write above is too small/fast to reliably make mpi_iotrace's
+    // own Bw_limit phase math land on a specific nonzero EMPI_DESIRED_BW_IWRITE
+    // (timing-dependent). Force one explicitly here to deterministically
+    // simulate "the MPI-IO layer just set a real target", and confirm the
+    // POSIX layer actually inherits and paces off it, per ioflags.h's
+    // BW_LIMIT_LAYER doc: standalone POSIX AIO with no MPI-IO in its own call
+    // chain always paces here, regardless of which layer last wrote the
+    // shared global.
+    EMPI_DESIRED_BW_IWRITE = 128.0L * 1024; // 128 KiB/s, inherited from "MPI-IO"
+
+    // 2. Direct POSIX aio_write, in the same process right after.
+    const char *posix_path = "tmio_mixed_posix.dat";
+    std::vector<char> posix_buf(256 * 1024, 'p'); // -> ~2s at the 128 KiB/s cap above
+    int fd = open(posix_path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    assert(fd >= 0);
+
+    struct aiocb cb = {};
+    cb.aio_fildes = fd;
+    cb.aio_buf = posix_buf.data();
+    cb.aio_nbytes = posix_buf.size();
+    cb.aio_offset = 0;
+
+    double t0 = MPI_Wtime();
+    assert(aio_write(&cb) == 0);
+    const struct aiocb *list[1] = {&cb};
+    assert(aio_suspend(list, 1, nullptr) == 0);
+    assert(aio_error(&cb) == 0);
+    assert(aio_return(&cb) == (ssize_t)posix_buf.size());
+    double elapsed = MPI_Wtime() - t0;
+    close(fd);
+    printf("POSIX AIO write: OK (took %.3f s, expected ~2s inherited from the MPI-IO-set target)\n", elapsed);
+    assert(elapsed >= 1.5 && elapsed < 30.0); // genuinely paced by the inherited value, and finite
+
+    // Correctness: both files must actually contain what was written,
+    // regardless of any cross-layer pacing interaction above.
+    char buf[128] = {};
+    int rfd = open(mpi_path, O_RDONLY);
+    assert(read(rfd, buf, sizeof(buf)) == (ssize_t)sizeof(mpi_msg));
+    assert(memcmp(buf, mpi_msg, sizeof(mpi_msg)) == 0);
+    close(rfd);
+
+    memset(buf, 'p', sizeof(buf));
+    char check[sizeof(buf)];
+    rfd = open(posix_path, O_RDONLY);
+    assert(read(rfd, check, sizeof(check)) == (ssize_t)sizeof(check));
+    assert(memcmp(check, buf, sizeof(check)) == 0); // spot-check: first bytes are all 'p'
+    close(rfd);
+
+    unlink(mpi_path);
+    unlink(posix_path);
+    printf("test_mixed_mpi_posix: OK\n");
+
+    MPI_Finalize();
+    return 0;
+}

--- a/test/posix_aio/test_posix_aio.cxx
+++ b/test/posix_aio/test_posix_aio.cxx
@@ -1,0 +1,253 @@
+// Correctness tests for TMIO's io_uring-backed POSIX AIO emulation
+// (BW_LIMIT_POSIX_AIO=1). See test/posix_aio/run_test.sh for how this is
+// built/run and how it is used as the RED/GREEN oracle: it also verifies (via
+// strace) that aio_write/aio_read actually go through io_uring, not glibc's
+// AIO passthrough, since correctness alone can't tell the two backends apart.
+#include <aio.h>
+#include <cassert>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <mpi.h>
+#include <unistd.h>
+
+static const char *PATH = "tmio_posix_aio_test.dat";
+
+static void test_write_roundtrip()
+{
+    int fd = open(PATH, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    assert(fd >= 0);
+
+    const char msg[] = "TMIO io_uring backed POSIX AIO write payload";
+    struct aiocb cb = {};
+    cb.aio_fildes = fd;
+    cb.aio_buf = (void *)msg;
+    cb.aio_nbytes = sizeof(msg);
+    cb.aio_offset = 0;
+
+    assert(aio_write(&cb) == 0);
+
+    const struct aiocb *list[1] = {&cb};
+    assert(aio_suspend(list, 1, nullptr) == 0);
+    assert(aio_error(&cb) == 0);
+    assert(aio_return(&cb) == (ssize_t)sizeof(msg));
+    close(fd);
+
+    int rfd = open(PATH, O_RDONLY);
+    char buf[sizeof(msg)] = {};
+    assert(read(rfd, buf, sizeof(buf)) == (ssize_t)sizeof(msg));
+    close(rfd);
+    assert(memcmp(buf, msg, sizeof(msg)) == 0);
+
+    printf("test_write_roundtrip: OK\n");
+}
+
+static void test_read_roundtrip()
+{
+    const char msg[] = "TMIO io_uring backed POSIX AIO read payload";
+    int wfd = open(PATH, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    assert(wfd >= 0);
+    assert(write(wfd, msg, sizeof(msg)) == (ssize_t)sizeof(msg));
+    close(wfd);
+
+    int fd = open(PATH, O_RDONLY);
+    assert(fd >= 0);
+
+    char buf[sizeof(msg)] = {};
+    struct aiocb cb = {};
+    cb.aio_fildes = fd;
+    cb.aio_buf = buf;
+    cb.aio_nbytes = sizeof(buf);
+    cb.aio_offset = 0;
+
+    assert(aio_read(&cb) == 0);
+
+    const struct aiocb *list[1] = {&cb};
+    assert(aio_suspend(list, 1, nullptr) == 0);
+    assert(aio_error(&cb) == 0);
+    assert(aio_return(&cb) == (ssize_t)sizeof(msg));
+    close(fd);
+
+    assert(memcmp(buf, msg, sizeof(msg)) == 0);
+
+    printf("test_read_roundtrip: OK\n");
+}
+
+static void test_lio_listio_wait()
+{
+    int fd = open(PATH, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    assert(fd >= 0);
+
+    const char part_a[] = "AAAAAAAAAA"; // 10 bytes
+    const char part_b[] = "BBBBBBBBBB"; // 10 bytes
+
+    struct aiocb cb_a = {}, cb_b = {};
+    cb_a.aio_fildes = fd;
+    cb_a.aio_buf = (void *)part_a;
+    cb_a.aio_nbytes = 10;
+    cb_a.aio_offset = 0;
+    cb_a.aio_lio_opcode = LIO_WRITE;
+
+    cb_b.aio_fildes = fd;
+    cb_b.aio_buf = (void *)part_b;
+    cb_b.aio_nbytes = 10;
+    cb_b.aio_offset = 10;
+    cb_b.aio_lio_opcode = LIO_WRITE;
+
+    struct aiocb *list[2] = {&cb_a, &cb_b};
+    assert(lio_listio(LIO_WAIT, list, 2, nullptr) == 0);
+    close(fd);
+
+    char buf[20] = {};
+    int rfd = open(PATH, O_RDONLY);
+    assert(read(rfd, buf, sizeof(buf)) == 20);
+    close(rfd);
+    assert(memcmp(buf, "AAAAAAAAAABBBBBBBBBB", 20) == 0);
+
+    printf("test_lio_listio_wait: OK\n");
+}
+
+static void test_lio_listio_nowait()
+{
+    int fd = open(PATH, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    assert(fd >= 0);
+
+    const char part_c[] = "CCCCCCCCCC"; // 10 bytes
+    const char part_d[] = "DDDDDDDDDD"; // 10 bytes
+
+    struct aiocb cb_c = {}, cb_d = {};
+    cb_c.aio_fildes = fd;
+    cb_c.aio_buf = (void *)part_c;
+    cb_c.aio_nbytes = 10;
+    cb_c.aio_offset = 0;
+    cb_c.aio_lio_opcode = LIO_WRITE;
+
+    cb_d.aio_fildes = fd;
+    cb_d.aio_buf = (void *)part_d;
+    cb_d.aio_nbytes = 10;
+    cb_d.aio_offset = 10;
+    cb_d.aio_lio_opcode = LIO_WRITE;
+
+    struct aiocb *list[2] = {&cb_c, &cb_d};
+    assert(lio_listio(LIO_NOWAIT, list, 2, nullptr) == 0);
+
+    const struct aiocb *wait_list[2] = {&cb_c, &cb_d};
+    assert(aio_suspend(wait_list, 2, nullptr) == 0);
+    while (aio_error(&cb_c) == EINPROGRESS || aio_error(&cb_d) == EINPROGRESS)
+        aio_suspend(wait_list, 2, nullptr);
+
+    assert(aio_return(&cb_c) == 10);
+    assert(aio_return(&cb_d) == 10);
+    close(fd);
+
+    char buf[20] = {};
+    int rfd = open(PATH, O_RDONLY);
+    assert(read(rfd, buf, sizeof(buf)) == 20);
+    close(rfd);
+    assert(memcmp(buf, "CCCCCCCCCCDDDDDDDDDD", 20) == 0);
+
+    printf("test_lio_listio_nowait: OK\n");
+}
+
+// Deterministic half of aio_cancel's contract: canceling a request that has
+// already completed must report AIO_ALLDONE, not AIO_CANCELED. (The other
+// half -- canceling one still in flight -- needs a slow enough transfer to
+// reliably race against, which only test_bw_limit.cxx's EMPI_DESIRED_BW_*
+// control gives us; see its test_cancel_in_flight.)
+static void test_cancel_already_done()
+{
+    int fd = open(PATH, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    assert(fd >= 0);
+
+    const char msg[] = "cancel-after-completion payload";
+    struct aiocb cb = {};
+    cb.aio_fildes = fd;
+    cb.aio_buf = (void *)msg;
+    cb.aio_nbytes = sizeof(msg);
+    cb.aio_offset = 0;
+
+    assert(aio_write(&cb) == 0);
+    const struct aiocb *list[1] = {&cb};
+    assert(aio_suspend(list, 1, nullptr) == 0);
+    assert(aio_error(&cb) == 0); // genuinely completed before we try to cancel it
+
+    assert(aio_cancel(fd, &cb) == AIO_ALLDONE);
+    assert(aio_return(&cb) == (ssize_t)sizeof(msg));
+    close(fd);
+
+    printf("test_cancel_already_done: OK\n");
+}
+
+// Other half of aio_cancel's contract: canceling a request that's genuinely
+// still in flight. A regular file completes too fast locally to reliably
+// race against, so this writes to a pipe filled to capacity with no reader --
+// the write physically cannot complete (0 bytes of buffer space exist) until
+// something reads or the request is canceled, giving a deterministic window.
+// The actual outcome (AIO_CANCELED vs AIO_NOTCANCELED) is kernel/timing
+// dependent -- POSIX allows either for a best-effort cancel -- so this only
+// asserts it's not wrongly reported AIO_ALLDONE and that the call itself
+// doesn't hang.
+static void test_cancel_in_flight()
+{
+    int fds[2];
+    assert(pipe(fds) == 0);
+    int read_fd = fds[0], write_fd = fds[1];
+
+    // Fill the pipe completely so the aio_write below has zero space to
+    // partially succeed into -- it must genuinely stay pending.
+    int flags = fcntl(write_fd, F_GETFL);
+    fcntl(write_fd, F_SETFL, flags | O_NONBLOCK);
+    char filler[4096];
+    memset(filler, 'f', sizeof(filler));
+    while (write(write_fd, filler, sizeof(filler)) > 0) {}
+    assert(errno == EAGAIN);
+    fcntl(write_fd, F_SETFL, flags); // restore blocking mode for aio_write
+
+    char payload[4096];
+    memset(payload, 'p', sizeof(payload));
+    struct aiocb cb = {};
+    cb.aio_fildes = write_fd;
+    cb.aio_buf = payload;
+    cb.aio_nbytes = sizeof(payload);
+
+    assert(aio_write(&cb) == 0);
+    usleep(50000); // let the kernel actually start (and block on) the write
+
+    int cancel_result = aio_cancel(write_fd, &cb);
+    assert(cancel_result == AIO_CANCELED || cancel_result == AIO_NOTCANCELED);
+
+    if (cancel_result == AIO_CANCELED)
+    {
+        assert(aio_error(&cb) == ECANCELED);
+    }
+    else
+    {
+        char drain[8192];
+        while (read(read_fd, drain, sizeof(drain)) > 0) {}
+        const struct aiocb *list[1] = {&cb};
+        aio_suspend(list, 1, nullptr);
+    }
+
+    close(read_fd);
+    close(write_fd);
+    printf("test_cancel_in_flight: OK\n");
+}
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+
+    test_write_roundtrip();
+    test_read_roundtrip();
+    test_lio_listio_wait();
+    test_lio_listio_nowait();
+    test_cancel_already_done();
+    test_cancel_in_flight();
+
+    unlink(PATH);
+    printf("All POSIX AIO tests passed.\n");
+
+    MPI_Finalize();
+    return 0;
+}


### PR DESCRIPTION
Reimplements aio_write/aio_read/aio_error/aio_return/aio_suspend/ lio_listio/aio_cancel on top of TMIO's own io_uring instance instead of glibc's AIO (BW_LIMIT_POSIX_AIO=1), giving observable submission/completion points to bandwidth-limit against. Pacing (pace_on_completion) mirrors the bw-limit MPICH's ROMIO patch: let the transfer run at full speed, then sleep out the remainder of the target duration, reading the same EMPI_DESIRED_BW_* globals Bw_limit already drives. BW_LIMIT_LAYER picks which layer paces MPI-IO-driven POSIX traffic so the two don't double-pace.

Also vendors the custom bandwidth-limiting MPICH build (dep/create_lib.sh, new bw_limit_iouring_library Makefile target) and fixes two real build bugs found along the way: liburing needed unversioned + SONAME symlinks for dlsym(RTLD_NEXT, ...) to find it at runtime, and the Makefile needed --no-as-needed since every liburing call here is dlsym-resolved rather than a direct symbol reference.

Verified: io_uring routing (strace-based), roundtrip correctness, aio_cancel (both completed and in-flight via a filled pipe), bandwidth pacing accuracy (<0.1% error across a 3-point sweep), a mixed MPI-IO + POSIX AIO workload in one process, the HACC-IO reference example with and without limiting, and the existing regression suite (9/10 pass; the 1 failure is a pre-existing unrelated environment gap).
